### PR TITLE
升级新版数据库以及相关查询代码，兼容旧格式

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # hyperf ip2region
 
-针对 hyperf 的 [ip2region](https://github.com/lionsoul2014/ip2region) 组件，采用速度最快的 [memorySearch](https://github.com/lionsoul2014/ip2region#ip2region-%E5%B9%B6%E5%8F%91%E4%BD%BF%E7%94%A8) 
+针对 hyperf 的 [ip2region](https://github.com/lionsoul2014/ip2region) 组件，采用速度最快的 [memorySearch](https://github.com/lionsoul2014/ip2region/blob/master/binding/php/ReadMe.md#%E7%BC%93%E5%AD%98%E6%95%B4%E4%B8%AA-xdb-%E6%95%B0%E6%8D%AE) 
 方式查询，在框架初始化时就将db文件载入内存
+
+参考
+- [ip2region](https://github.com/lionsoul2014/ip2region?tab=readme-ov-file#2%E6%8A%80%E6%9C%AF%E8%B5%84%E6%BA%90%E5%88%86%E4%BA%AB)
+- [数据结构和查询过程](https://mp.weixin.qq.com/s/ndjzu0BgaeBmDOCw5aqHUg)
+- [兼容Ip2Region](https://github.com/zoujingli/ip2region/blob/master/Ip2Region.php)
 
 ## 安装
 

--- a/src/Ip2region.php
+++ b/src/Ip2region.php
@@ -9,74 +9,160 @@ declare(strict_types=1);
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Trrtly\Ip2region;
 
 use Exception;
 
 class Ip2region
 {
-    public const INDEX_BLOCK_LENGTH = 12;
+    public const HeaderInfoLength = 256;
 
-    public const TOTAL_HEADER_LENGTH = 8192;
+    public const VectorIndexRows = 256;
 
-    /**
-     * db file handler.
-     */
-    private $dbFileHandler;
+    public const VectorIndexCols = 256;
 
-    /**
-     * header block info.
-     */
-    private $HeaderSip;
+    public const VectorIndexSize = 8;
 
-    private $HeaderPtr;
+    public const SegmentIndexSize = 14;
 
-    private $headerLen = 0;
+    // vector index in binary string.
+    // string decode will be faster than the map based Array.
+    private $vectorIndex;
 
-    private $totalBlocks = 0;
+    // xdb content buffer
+    private $contentBuff;
 
     /**
-     * for memory mode only
-     *  the original db binary string.
-     */
-    private $dbBinStr;
-
-    private $dbFile;
-
-    private $firstIndexPtr;
-
-    private $lastIndexPtr;
-
-    /**
-     * construct method.
+     * initialize the xdb searcher.
      *
-     * @param null|mixed $ip2regionFile
+     * @param null|mixed $dbFile
      * @throws Exception
      */
-    public function __construct($ip2regionFile = null)
+    public function __construct($dbFile = null)
     {
-        $this->dbFile = is_null($ip2regionFile) ? __DIR__ . '/db/ip2region.db' : $ip2regionFile;
-        //check and load the binary string for the first time
-        $this->dbBinStr = file_get_contents($this->dbFile);
-        if (!$this->dbBinStr) {
-            throw new Exception("Fail to open the db file {$this->dbFile}");
+        if (is_null($dbFile)) {
+            $dbFile = __DIR__ . DIRECTORY_SEPARATOR . 'db' . DIRECTORY_SEPARATOR . 'ip2region.xdb';
         }
-        $this->firstIndexPtr = self::getLong($this->dbBinStr, 0);
-        $this->lastIndexPtr = self::getLong($this->dbBinStr, 4);
-        $this->totalBlocks = ($this->lastIndexPtr - $this->firstIndexPtr) / self::INDEX_BLOCK_LENGTH + 1;
+
+        $cBuff = file_get_contents($dbFile);
+        if (! $cBuff) {
+            throw new Exception("Fail to open the db file {$dbFile}");
+        }
+
+        $this->vectorIndex = null;
+        $this->contentBuff = $cBuff;
     }
 
     /**
-     * destruct method, resource destroy.
+     * 获取文件头信息.
      */
-    public function __destruct()
+    public function getHeader(): ?array
     {
-        if ($this->dbFileHandler != null) {
-            fclose($this->dbFileHandler);
+        $buff = $this->read(0, self::HeaderInfoLength);
+        if ($buff === false) {
+            return null;
         }
-        $this->dbBinStr = null;
-        $this->HeaderSip = null;
-        $this->HeaderPtr = null;
+
+        // read bytes length checking
+        if (strlen($buff) != self::HeaderInfoLength) {
+            return null;
+        }
+
+        // return the decoded header info
+        return [
+            'version' => self::getShort($buff, 0),
+            'indexPolicy' => self::getShort($buff, 2),
+            'createdAt' => self::getLong($buff, 4),
+            'startIndexPtr' => self::getLong($buff, 8),
+            'endIndexPtr' => self::getLong($buff, 12),
+        ];
+    }
+
+    /**
+     * find the region info for the specified ip address.
+     *
+     * @param string|int $ip
+     * @throws Exception
+     */
+    public function search($ip): ?string
+    {
+        // check and convert the sting ip to a 4-bytes long
+        if (is_string($ip)) {
+            $t = self::ip2long($ip);
+            if ($t === null) {
+                throw new Exception("invalid ip address `{$ip}`");
+            }
+            $ip = $t;
+        }
+
+        // locate the segment index block based on the vector index
+        $il0 = ($ip >> 24) & 0xFF;
+        $il1 = ($ip >> 16) & 0xFF;
+        $idx = $il0 * self::VectorIndexCols * self::VectorIndexSize + $il1 * self::VectorIndexSize;
+        if ($this->vectorIndex != null) {
+            $sPtr = self::getLong($this->vectorIndex, $idx);
+            $ePtr = self::getLong($this->vectorIndex, $idx + 4);
+        } elseif ($this->contentBuff != null) {
+            $sPtr = self::getLong($this->contentBuff, self::HeaderInfoLength + $idx);
+            $ePtr = self::getLong($this->contentBuff, self::HeaderInfoLength + $idx + 4);
+        } else {
+            // read the vector index block
+            $buff = $this->read(self::HeaderInfoLength + $idx, 8);
+            if ($buff === null) {
+                throw new Exception("failed to read vector index at {$idx}");
+            }
+
+            $sPtr = self::getLong($buff, 0);
+            $ePtr = self::getLong($buff, 4);
+        }
+
+        // printf("sPtr: %d, ePtr: %d\n", $sPtr, $ePtr);
+
+        // binary search the segment index to get the region info
+        $dataLen = 0;
+        $dataPtr = null;
+        $l = 0;
+        $h = ($ePtr - $sPtr) / self::SegmentIndexSize;
+        while ($l <= $h) {
+            $m = ($l + $h) >> 1;
+            $p = $sPtr + $m * self::SegmentIndexSize;
+
+            // read the segment index
+            $buff = $this->read($p, self::SegmentIndexSize);
+            if ($buff == null) {
+                throw new Exception("failed to read segment index at {$p}");
+            }
+
+            $sip = self::getLong($buff, 0);
+            if ($ip < $sip) {
+                $h = $m - 1;
+            } else {
+                $eip = self::getLong($buff, 4);
+                if ($ip > $eip) {
+                    $l = $m + 1;
+                } else {
+                    $dataLen = self::getShort($buff, 8);
+                    $dataPtr = self::getLong($buff, 10);
+                    break;
+                }
+            }
+        }
+
+        // match nothing interception.
+        // @TODO: could this even be a case ?
+        // printf("dataLen: %d, dataPtr: %d\n", $dataLen, $dataPtr);
+        if ($dataPtr == null) {
+            return null;
+        }
+
+        // load and return the region data
+        $buff = $this->read($dataPtr, $dataLen);
+        if ($buff == null) {
+            return null;
+        }
+
+        return $buff;
     }
 
     /**
@@ -85,288 +171,84 @@ class Ip2region
      * Note:
      * invoke it once before put it to public invoke could make it thread safe.
      *
-     * @param string $ip
+     * @param string|int $ip
      * @throws Exception
-     * @return null|array
      */
-    public function memorySearch($ip)
+    public function memorySearch($ip): ?array
     {
-        if (is_string($ip)) {
-            $ip = self::safeIp2long($ip);
-        }
-        //binary search to define the data
-        $l = 0;
-        $h = $this->totalBlocks;
-        $dataPtr = 0;
-        while ($l <= $h) {
-            $m = (($l + $h) >> 1);
-            $p = $this->firstIndexPtr + $m * self::INDEX_BLOCK_LENGTH;
-            $sip = self::getLong($this->dbBinStr, $p);
-            if ($ip < $sip) {
-                $h = $m - 1;
-            } else {
-                $eip = self::getLong($this->dbBinStr, $p + 4);
-                if ($ip > $eip) {
-                    $l = $m + 1;
-                } else {
-                    $dataPtr = self::getLong($this->dbBinStr, $p + 8);
-                    break;
-                }
-            }
-        }
-        //not matched just stop it here
-        if ($dataPtr == 0) {
+        $region = $this->search($ip);
+
+        if (is_null($region)) {
             return null;
         }
-        //get the data
-        $dataLen = (($dataPtr >> 24) & 0xFF);
-        $dataPtr = ($dataPtr & 0x00FFFFFF);
-        return [
-            'city_id' => self::getLong($this->dbBinStr, $dataPtr),
-            'region' => substr($this->dbBinStr, $dataPtr + 4, $dataLen - 4),
-        ];
+
+        return ['city_id' => 0, 'region' => $region];
     }
 
     /**
      * get the data block through the specified ip address or long ip numeric with binary search algorithm.
      *
-     * @param mixed $ip
-     * @return array|null Array or NULL for any error
+     * @param string|int $ip
      * @throws Exception
      */
-    public function binarySearch($ip)
+    public function binarySearch($ip): ?array
     {
-        //check and conver the ip address
-        if (is_string($ip)) {
-            $ip = self::safeIp2long($ip);
-        }
-        $firstIndexPtr = 0;
-        if ($this->totalBlocks == 0) {
-            //check and open the original db file
-            if ($this->dbFileHandler == null) {
-                $this->dbFileHandler = fopen($this->dbFile, 'r');
-                if (!$this->dbFileHandler) {
-                    throw new Exception("Fail to open the db file {$this->dbFile}");
-                }
-            }
-            fseek($this->dbFileHandler, 0);
-            $superBlock = fread($this->dbFileHandler, 8);
-            $firstIndexPtr = self::getLong($superBlock, 0);
-            $lastIndexPtr = self::getLong($superBlock, 4);
-            $this->totalBlocks = ($lastIndexPtr - $firstIndexPtr) / self::INDEX_BLOCK_LENGTH + 1;
-        }
-        //binary search to define the data
-        $l = 0;
-        $h = $this->totalBlocks;
-        $dataPtr = 0;
-        while ($l <= $h) {
-            $m = (($l + $h) >> 1);
-            $p = $m * self::INDEX_BLOCK_LENGTH;
-            fseek($this->dbFileHandler, $firstIndexPtr + $p);
-            $buffer = fread($this->dbFileHandler, self::INDEX_BLOCK_LENGTH);
-            $sip = self::getLong($buffer, 0);
-            if ($ip < $sip) {
-                $h = $m - 1;
-            } else {
-                $eip = self::getLong($buffer, 4);
-                if ($ip > $eip) {
-                    $l = $m + 1;
-                } else {
-                    $dataPtr = self::getLong($buffer, 8);
-                    break;
-                }
-            }
-        }
-        //not matched just stop it here
-        if ($dataPtr == 0) {
-            return null;
-        }
-        //get the data
-        $dataLen = (($dataPtr >> 24) & 0xFF);
-        $dataPtr = ($dataPtr & 0x00FFFFFF);
-        fseek($this->dbFileHandler, $dataPtr);
-        $data = fread($this->dbFileHandler, $dataLen);
-        return [
-            'city_id' => self::getLong($data, 0),
-            'region' => substr($data, 4),
-        ];
+        return $this->memorySearch($ip);
     }
 
     /**
      * get the data block associated with the specified ip with b-tree search algorithm.
      * Note: not thread safe.
      *
-     * @param string ip
-     * @param mixed $ip
+     * @param string|int $ip
      * @throws Exception
-     * @return mixed Array for NULL for any error
      */
-    public function btreeSearch($ip)
+    public function btreeSearch($ip): ?array
     {
-        if (is_string($ip)) {
-            $ip = self::safeIp2long($ip);
-        }
-        //check and load the header
-        if ($this->HeaderSip == null) {
-            //check and open the original db file
-            if ($this->dbFileHandler == null) {
-                $this->dbFileHandler = fopen($this->dbFile, 'r');
-                if ($this->dbFileHandler == false) {
-                    throw new Exception("Fail to open the db file {$this->dbFile}");
-                }
-            }
-            fseek($this->dbFileHandler, 8);
-            $buffer = fread($this->dbFileHandler, self::TOTAL_HEADER_LENGTH);
-
-            //fill the header
-            $idx = 0;
-            $this->HeaderSip = [];
-            $this->HeaderPtr = [];
-            for ($i = 0; $i < self::TOTAL_HEADER_LENGTH; $i += 8) {
-                $startIp = self::getLong($buffer, $i);
-                $dataPtr = self::getLong($buffer, $i + 4);
-                if ($dataPtr == 0) {
-                    break;
-                }
-                $this->HeaderSip[] = $startIp;
-                $this->HeaderPtr[] = $dataPtr;
-                ++$idx;
-            }
-            $this->headerLen = $idx;
-        }
-
-        //1. define the index block with the binary search
-        $l = 0;
-        $h = $this->headerLen;
-        $sptr = 0;
-        $eptr = 0;
-        while ($l <= $h) {
-            $m = (($l + $h) >> 1);
-
-            //perfetc matched, just return it
-            if ($ip == $this->HeaderSip[$m]) {
-                if ($m > 0) {
-                    $sptr = $this->HeaderPtr[$m - 1];
-                    $eptr = $this->HeaderPtr[$m];
-                } else {
-                    $sptr = $this->HeaderPtr[$m];
-                    $eptr = $this->HeaderPtr[$m + 1];
-                }
-
-                break;
-            }
-
-            //less then the middle value
-            if ($ip < $this->HeaderSip[$m]) {
-                if ($m == 0) {
-                    $sptr = $this->HeaderPtr[$m];
-                    $eptr = $this->HeaderPtr[$m + 1];
-                    break;
-                }
-                if ($ip > $this->HeaderSip[$m - 1]) {
-                    $sptr = $this->HeaderPtr[$m - 1];
-                    $eptr = $this->HeaderPtr[$m];
-                    break;
-                }
-                $h = $m - 1;
-            } else {
-                if ($m == $this->headerLen - 1) {
-                    $sptr = $this->HeaderPtr[$m - 1];
-                    $eptr = $this->HeaderPtr[$m];
-                    break;
-                }
-                if ($ip <= $this->HeaderSip[$m + 1]) {
-                    $sptr = $this->HeaderPtr[$m];
-                    $eptr = $this->HeaderPtr[$m + 1];
-                    break;
-                }
-                $l = $m + 1;
-            }
-        }
-
-        //match nothing just stop it
-        if ($sptr == 0) {
-            return null;
-        }
-
-        //2. search the index blocks to define the data
-        $blockLen = $eptr - $sptr;
-        fseek($this->dbFileHandler, $sptr);
-        $index = fread($this->dbFileHandler, $blockLen + self::INDEX_BLOCK_LENGTH);
-
-        $dataPtr = 0;
-        $l = 0;
-        $h = $blockLen / self::INDEX_BLOCK_LENGTH;
-        while ($l <= $h) {
-            $m = (($l + $h) >> 1);
-            $p = (int) ($m * self::INDEX_BLOCK_LENGTH);
-            $sip = self::getLong($index, $p);
-            if ($ip < $sip) {
-                $h = $m - 1;
-            } else {
-                $eip = self::getLong($index, $p + 4);
-                if ($ip > $eip) {
-                    $l = $m + 1;
-                } else {
-                    $dataPtr = self::getLong($index, $p + 8);
-                    break;
-                }
-            }
-        }
-
-        //not matched
-        if ($dataPtr == 0) {
-            return null;
-        }
-
-        //3. get the data
-        $dataLen = (($dataPtr >> 24) & 0xFF);
-        $dataPtr = ($dataPtr & 0x00FFFFFF);
-
-        fseek($this->dbFileHandler, $dataPtr);
-        $data = fread($this->dbFileHandler, $dataLen);
-        return [
-            'city_id' => self::getLong($data, 0),
-            'region' => substr($data, 4),
-        ];
+        return $this->memorySearch($ip);
     }
 
-    /**
-     * safe self::safeIp2long function.
-     *
-     * @param mixed $ip
-     *
-     * @return false|int|string
-     */
-    public static function safeIp2long($ip)
+    // --- static util functions ----
+
+    // convert a string ip to long
+    public static function ip2long($ip)
     {
         $ip = ip2long($ip);
+        if ($ip === false) {
+            return null;
+        }
+
         // convert signed int to unsigned int if on 32 bit operating system
         if ($ip < 0 && PHP_INT_SIZE == 4) {
             $ip = sprintf('%u', $ip);
         }
+
         return $ip;
     }
 
-    /**
-     * read a long from a byte buffer.
-     *
-     * @param mixed $b
-     * @param mixed $offset
-     * @return int|string
-     */
-    public static function getLong($b, $offset)
+    // read a 4bytes long from a byte buffer
+    public static function getLong($b, $idx)
     {
-        $val = (
-            (ord($b[$offset++])) |
-            (ord($b[$offset++]) << 8) |
-            (ord($b[$offset++]) << 16) |
-            (ord($b[$offset]) << 24)
-        );
+        $val = ord($b[$idx]) | (ord($b[$idx + 1]) << 8)
+            | (ord($b[$idx + 2]) << 16) | (ord($b[$idx + 3]) << 24);
+
         // convert signed int to unsigned int if on 32 bit operating system
         if ($val < 0 && PHP_INT_SIZE == 4) {
             $val = sprintf('%u', $val);
         }
+
         return $val;
+    }
+
+    // read a 2bytes short from a byte buffer
+    public static function getShort($b, $idx)
+    {
+        return ord($b[$idx]) | (ord($b[$idx + 1]) << 8);
+    }
+
+    // read specified bytes from the specified index
+    private function read($offset, $len)
+    {
+        return substr($this->contentBuff, $offset, $len);
     }
 }

--- a/tests/Cases/Ip2regionTest.php
+++ b/tests/Cases/Ip2regionTest.php
@@ -23,4 +23,13 @@ class Ip2regionTest extends AbstractTestCase
         $this->assertArrayHasKey('region', $region);
         $this->assertStringContainsString('厦门', $region['region']);
     }
+
+    public function testIp2regionGetHeader()
+    {
+        /** @var Ip2region $ip2region */
+        $ip2region = make(Ip2region::class);
+        $header = $ip2region->getHeader();
+        $this->assertIsArray($header);
+        $this->assertArrayHasKey('version', $header);
+    }
 }


### PR DESCRIPTION
针对 hyperf 目前只移植了 memorySearch 相关的代码，兼容原调用方式。

参考
- [ip2region](https://github.com/lionsoul2014/ip2region?tab=readme-ov-file#2%E6%8A%80%E6%9C%AF%E8%B5%84%E6%BA%90%E5%88%86%E4%BA%AB)
- [数据结构和查询过程](https://mp.weixin.qq.com/s/ndjzu0BgaeBmDOCw5aqHUg)
- [兼容Ip2Region](https://github.com/zoujingli/ip2region/blob/master/Ip2Region.php)
