### PR TITLE
升级到 hyperf3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
-        "hyperf/testing": "3.0.*",
+        "hyperf/testing": "~3.1.0",
         "mockery/mockery": "^1.0",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=7.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="tests/bootstrap.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         verbose="true"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuite name="Testsuite">
-        <directory>./tests/</directory>
-    </testsuite>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuite name="Testsuite">
+    <directory>./tests/</directory>
+  </testsuite>
 </phpunit>

--- a/tests/Cases/Ip2regionTest.php
+++ b/tests/Cases/Ip2regionTest.php
@@ -13,6 +13,8 @@ namespace HyperfTest\Cases;
 
 use Trrtly\Ip2region\Ip2region;
 
+use function Hyperf\Support\make;
+
 class Ip2regionTest extends AbstractTestCase
 {
     public function testIp2regionMemorySearch()


### PR DESCRIPTION
因为单元测试中引用了 hyperf/testing 所以需要更新到 hyperf/3.1，release 需要升级一个版本。